### PR TITLE
Sneakemail.com domains

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -11,3 +11,7 @@ slmail.me
 gmail.com
 zoho.com
 outlook.com
+sneakemail.com
+liamekaens.com
+snkmail.com
+snkml.com

--- a/list.txt
+++ b/list.txt
@@ -10020,7 +10020,6 @@ lhsdv.com
 lhslhw.com
 lhtstci.com
 lhzoom.com
-liamekaens.com
 liaphoto.com
 liastoen.com
 libbywrites.com
@@ -15516,15 +15515,12 @@ snailmail.website
 snakebite.com
 snakebutt.com
 snapunit.com
-sneakemail.com
 sneaker-shops.com
 sneakmail.de
 sneakyreviews.com
 snece.com
 snellingpersonnel.com
 snipemail4u.men
-snkmail.com
-snkml.com
 snlw.com
 snout.9amail.top
 snow.2amail.top


### PR DESCRIPTION
Sneakemail.com addresses aren't temporary.
See also
https://github.com/FGRibreau/mailchecker/issues/139
https://github.com/FGRibreau/mailchecker/pull/150
https://github.com/FGRibreau/mailchecker/pull/319


P.S.
Just to be clear, the service doesn't offer temporary or disposable addresses (even though they call them that on the homepage).
All emails are forwarded to a central inbox, the addresses never expire and once you create one it is yours forever.
You can disable an address and re-enable it later.
There is nothing temporary about them.